### PR TITLE
Sort config keys; remove duplicates

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,47 +4,41 @@ module.exports = {
     'plugin:flowtype/recommended',
     'prettier',
     'prettier/flowtype',
-    'prettier/react',
+    'prettier/react'
   ],
   env: {
-    'jest/globals': true,
+    'jest/globals': true
   },
   parser: 'babel-eslint',
   plugins: ['flowtype', 'jest', 'prettier'],
   rules: {
-    'prettier/prettier': ['error', 'fb'],
-    'no-use-before-define': 0,
-    'react/jsx-filename-extension': 0,
-    'react/prefer-stateless-function': 0, // temporarily disable
-    'no-underscore-dangle': 0,
-    'no-use-before-define': 0,
-    'no-unused-expressions': 0,
-    'new-cap': 0,
-    'no-plusplus': 0,
-    'no-class-assign': 0,
-    'no-duplicate-imports': 0,
-    'react/jsx-filename-extension': [0, {extensions: ['.js', '.jsx']}],
-    'react/sort-comp': 0,
-    'react/forbid-prop-types': 1,
-    'react/prop-types': 0,
-    'react/require-default-props': 0,
-    'import/no-duplicates': 0,
-    'import/extensions': 0,
-    'import/no-unresolved': 0,
-    'import/no-dynamic-require': 0,
-
-    'flowtype/boolean-style': [2, 'boolean'],
     'flowtype/no-weak-types': 1,
     'flowtype/require-parameter-type': 2,
     'flowtype/require-return-type': [
       0,
       'always',
       {
-        annotateUndefined: 'never',
-      },
+        annotateUndefined: 'never'
+      }
     ],
     'flowtype/require-valid-file-annotation': 2,
-    'flowtype/use-flow-type': 1,
-    'flowtype/valid-syntax': 1,
-  },
+    'import/extensions': 0,
+    'import/no-duplicates': 0,
+    'import/no-dynamic-require': 0,
+    'import/no-unresolved': 0,
+    'new-cap': 0,
+    'no-class-assign': 0,
+    'no-duplicate-imports': 0,
+    'no-plusplus': 0,
+    'no-underscore-dangle': 0,
+    'no-unused-expressions': 0,
+    'no-use-before-define': 0,
+    'prettier/prettier': ['error', 'fb'],
+    'react/forbid-prop-types': 1,
+    'react/jsx-filename-extension': [0, {extensions: ['.js', '.jsx']}],
+    'react/prefer-stateless-function': 0,
+    'react/prop-types': 0,
+    'react/require-default-props': 0,
+    'react/sort-comp': 0
+  }
 };


### PR DESCRIPTION
Removed some unnecessary Flowtype rules, which are already available in `plugin:flowtype/recommended`, some duplicates and sorted alphabetically