### PR TITLE
feature: add Node config

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Default config:
     "browser": true,
     "es6": true,
     "node": true,
-    'react-native/react-native': true,
+    "react-native/react-native": true
   }
 }
 ```
@@ -38,7 +38,7 @@ Node config:
   "env": {
     "browser": true,
     "es6": true,
-    "node": true,
+    "node": true
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -2,24 +2,43 @@
 
 [![Greenkeeper badge](https://badges.greenkeeper.io/callstack/eslint-config-callstack.svg)](https://greenkeeper.io/)
 
-Callstack eslint config utilizing Flow, Prettier and Jest support.
+Callstack ESLint config utilizing Flow/TypeScript, Prettier, Jest, React and React Native.
 
 Plugins and configs used:
-* [eslint-config-prettier](https://yarnpkg.com/en/package/eslint-config-prettier)
-* [eslint-plugin-prettier](https://yarnpkg.com/en/package/eslint-plugin-prettier)
-* [eslint-plugin-flowtype](https://yarnpkg.com/en/package/eslint-plugin-flowtype)
-* [eslint-plugin-jest](https://yarnpkg.com/en/package/eslint-plugin-jest)
-* [eslint-plugin-react-native](https://yarnpkg.com/en/package/eslint-plugin-react-native)
-* [eslint-plugin-import](https://yarnpkg.com/en/package/eslint-plugin-import)
-* [eslint-plugin-react-hooks](https://yarnpkg.com/en/package/eslint-plugin-react-hooks)
+* Default config (w/ React and React Native):
+  * Node config
+  * [eslint-plugin-react](https://yarnpkg.com/en/package/eslint-plugin-react)
+  * [eslint-plugin-react-native](https://yarnpkg.com/en/package/eslint-plugin-react-native)
+  * [eslint-plugin-react-hooks](https://yarnpkg.com/en/package/eslint-plugin-react-hooks)
+* Node config:
+  * [eslint-config-prettier](https://yarnpkg.com/en/package/eslint-config-prettier)
+  * [eslint-plugin-prettier](https://yarnpkg.com/en/package/eslint-plugin-prettier)
+  * [eslint-plugin-jest](https://yarnpkg.com/en/package/eslint-plugin-jest)
+  * [eslint-plugin-import](https://yarnpkg.com/en/package/eslint-plugin-import)
+  * [eslint-plugin-flowtype](https://yarnpkg.com/en/package/eslint-plugin-flowtype)
+  * [@typescript-eslint/eslint-plugin](https://yarnpkg.com/en/package/@typescript-eslint/eslint-plugin)
 
 Additionally, it sets these environments:
+
+Default config:
 ```json
 {
   "env": {
     "browser": true,
     "es6": true,
-    "node": true
+    "node": true,
+    'react-native/react-native': true,
+  }
+}
+```
+
+Node config:
+```json
+{
+  "env": {
+    "browser": true,
+    "es6": true,
+    "node": true,
   }
 }
 ```
@@ -34,11 +53,19 @@ yarn add --dev eslint @callstack/eslint-config
 
 ## Usage
 
-Add to your eslint config (`.eslintrc`, or `eslintConfig` field in `package.json`):
+Add to your ESLint config (`.eslintrc`, or `eslintConfig` field in `package.json`):
 
 ```json
 {
     "extends": "@callstack"
+}
+```
+
+or
+
+```json
+{
+    "extends": "@callstack/eslint-config/node"
 }
 ```
 
@@ -54,3 +81,16 @@ Add to your eslint config (`.eslintrc`, or `eslintConfig` field in `package.json
 }
 ```
 
+### TypeScript
+
+In order to use this config in TypeScript project make sure you have installed following dependencies:
+
+* [`@typescript-eslint/eslint-plugin`](https://yarnpkg.com/en/package/@typescript-eslint/eslint-plugin)
+* [`@typescript-eslint/parser`](https://yarnpkg.com/en/package/@typescript-eslint/parser)
+* [`typescript`](https://yarnpkg.com/en/package/typescript)
+
+Then when running ESLint add `--ext '.js,.ts'` (you might need also `.jsx, .tsx`) option, for example:
+
+```bash
+yarn eslint --ext '.js,.ts' ./src
+```

--- a/index.js
+++ b/index.js
@@ -1,61 +1,27 @@
-const restrictedGlobals = require('eslint-restricted-globals');
 const OFF = 0;
 const WARNING = 1;
 const ERROR = 2;
 
 module.exports = {
   extends: [
-    'eslint:recommended',
-    'plugin:flowtype/recommended',
-    'plugin:jest/recommended',
+    require.resolve('./node.js'),
     'plugin:react/recommended',
-    'prettier',
-    'prettier/flowtype',
     'prettier/react',
   ],
   env: {
-    browser: true,
-    es6: true,
-    node: true,
     'react-native/react-native': true,
   },
   plugins: [
-    'jest',
-    'prettier',
     'react',
     'react-native',
     'react-hooks',
-    'import',
   ],
   parserOptions: {
-    sourceType: 'module',
     ecmaFeatures: {
       jsx: true,
     },
   },
   rules: {
-    'import/extensions': OFF,
-    'import/no-dynamic-require': OFF,
-    'import/no-unresolved': ERROR,
-    'import/prefer-default-export': OFF,
-    'no-restricted-globals': [ERROR].concat(restrictedGlobals),
-    'no-restricted-syntax': [ERROR, 'WithStatement'],
-    'prettier/prettier': [
-      ERROR,
-      {
-        singleQuote: true,
-        trailingComma: 'es5',
-      },
-    ],
-    'import/no-extraneous-dependencies': [
-      ERROR,
-      {
-        devDependencies: [
-          '**/__tests__/**/*.[jt]s?(x)',
-          '**/?(*.)+(spec|test).[tj]s?(x)',
-        ],
-      },
-    ],
     'react/prop-types': OFF,
     'react/display-name': OFF,
     'react-native/no-unused-styles': ERROR,
@@ -76,41 +42,4 @@ module.exports = {
       version: 'detect',
     },
   },
-  overrides: [
-    {
-      files: ['*.js'],
-      parser: 'babel-eslint',
-      plugins: ['flowtype'],
-      rules: {
-        'flowtype/no-weak-types': WARNING,
-        'flowtype/require-parameter-type': OFF,
-        'flowtype/require-return-type': [
-          OFF,
-          'always',
-          { annotateUndefined: 'never' },
-        ],
-        'flowtype/require-valid-file-annotation': ERROR,
-      },
-    },
-    {
-      files: ['*.ts', '*.tsx'],
-      parser: '@typescript-eslint/parser',
-      plugins: ['@typescript-eslint/eslint-plugin'],
-      rules: {
-        '@typescript-eslint/no-unused-vars': [
-          ERROR,
-          { argsIgnorePattern: '^_' },
-        ],
-        'no-dupe-class-members': OFF,
-        'no-unused-vars': OFF,
-      },
-    },
-    {
-      files: ['*.{spec,test}.{js,ts,tsx}', '**/__tests__/**/*.{js,ts,tsx}'],
-      env: {
-        jest: true,
-        'jest/globals': true,
-      },
-    },
-  ],
 };

--- a/node.js
+++ b/node.js
@@ -1,0 +1,89 @@
+const restrictedGlobals = require('eslint-restricted-globals');
+const OFF = 0;
+const WARNING = 1;
+const ERROR = 2;
+
+module.exports = {
+  extends: [
+    'eslint:recommended',
+    'plugin:flowtype/recommended',
+    'plugin:jest/recommended',
+    'prettier',
+    'prettier/flowtype',
+    'plugin:import/typescript'
+  ],
+  env: {
+    browser: true,
+    es6: true,
+    node: true,
+  },
+  plugins: [
+    'jest',
+    'prettier',
+    'import',
+  ],
+  parserOptions: {
+    sourceType: 'module',
+  },
+  rules: {
+    'import/extensions': OFF,
+    'import/no-dynamic-require': OFF,
+    'import/no-unresolved': ERROR,
+    'import/prefer-default-export': OFF,
+    'no-restricted-globals': [ERROR].concat(restrictedGlobals),
+    'no-restricted-syntax': [ERROR, 'WithStatement'],
+    'prettier/prettier': [
+      ERROR,
+      {
+        singleQuote: true,
+        trailingComma: 'es5',
+      },
+    ],
+    'import/no-extraneous-dependencies': [
+      ERROR,
+      {
+        devDependencies: [
+          '**/__tests__/**/*.[jt]s?(x)',
+          '**/?(*.)+(spec|test).[tj]s?(x)',
+        ],
+      },
+    ],
+  },
+  overrides: [
+    {
+      files: ['*.js'],
+      parser: 'babel-eslint',
+      plugins: ['flowtype'],
+      rules: {
+        'flowtype/no-weak-types': WARNING,
+        'flowtype/require-parameter-type': OFF,
+        'flowtype/require-return-type': [
+          OFF,
+          'always',
+          { annotateUndefined: 'never' },
+        ],
+        'flowtype/require-valid-file-annotation': ERROR,
+      },
+    },
+    {
+      files: ['*.ts', '*.tsx'],
+      parser: '@typescript-eslint/parser',
+      plugins: ['@typescript-eslint/eslint-plugin'],
+      rules: {
+        '@typescript-eslint/no-unused-vars': [
+          ERROR,
+          { argsIgnorePattern: '^_' },
+        ],
+        'no-dupe-class-members': OFF,
+        'no-unused-vars': OFF,
+      },
+    },
+    {
+      files: ['*.{spec,test}.{js,ts,tsx}', '**/__tests__/**/*.{js,ts,tsx}'],
+      env: {
+        jest: true,
+        'jest/globals': true,
+      },
+    },
+  ],
+};


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Adds Node config without React and React Native specific plugins, envs and rules. The default config is for React and React Native and under-the-hood is using Node config, but tweaked.

### Test plan

`yarn test` is not failing, which means default config and Node config are valid.
