### PR TITLE
feat: Bump eslint-plugin-react

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "eslint-plugin-jest": "^22.4.1",
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-promise": "^4.1.1",
-    "eslint-plugin-react": "^7.12.4",
+    "eslint-plugin-react": "^7.13.0",
     "eslint-plugin-react-hooks": "^1.6.0",
-    "eslint-plugin-react-native": "^3.6.0",
+    "eslint-plugin-react-native": "^3.7.0",
     "eslint-restricted-globals": "^0.2.0",
     "prettier": "^1.17.0"
   },


### PR DESCRIPTION
We have an eslint-config package that depends on the @callstack/eslint-config, and adds a few overrides and eslint-plugin-react-redux. 
We had a need to update eslint-plugin-react to 7.13.0, which then requires  eslint-plugin-import  as a peerDependency. This means the apps have to add the import plugin to their package.json.

Bumping the package version here so the peerDependency is encapsulated here.

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
