### PR TITLE
feat: Ignore args required for strong typing correctness

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ module.exports = {
     'react/prop-types': OFF,
     'react/display-name': OFF,
     'react-native/no-unused-styles': ERROR,
+    'no-unused-vars': [ERROR, { 'argsIgnorePattern': '^_', 'caughtErrorsIgnorePattern': '^_' }]
     'react-native/split-platform-components': OFF,
     'react-native/no-inline-styles': WARNING,
     'react-native/no-color-literals': WARNING,

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports = {
     'react/prop-types': OFF,
     'react/display-name': OFF,
     'react-native/no-unused-styles': ERROR,
-    'no-unused-vars': [ERROR, { 'argsIgnorePattern': '^_', 'caughtErrorsIgnorePattern': '^_' }]
+    'no-unused-vars': [ERROR, { 'argsIgnorePattern': '^_', 'caughtErrorsIgnorePattern': '^_' }],
     'react-native/split-platform-components': OFF,
     'react-native/no-inline-styles': WARNING,
     'react-native/no-color-literals': WARNING,

--- a/test/index.js
+++ b/test/index.js
@@ -14,11 +14,17 @@ export default class Bool extends React.Component<Props> {
     let token = await this.current.keepOwnership();
     return this.props.updateMode(token);
   };
+
+  animate = (_: ?number) => {};
 }
 
 export function Hook() {
   React.useEffect(() => {
-    localStorage.setItem('formData', 'data');
+    try {
+      localStorage.setItem('formData', 'data');
+    }
+    catch (_hugeObject) {
+    }
   });
 
   return <Bool />;

--- a/test/index.js
+++ b/test/index.js
@@ -22,8 +22,8 @@ export function Hook() {
   React.useEffect(() => {
     try {
       localStorage.setItem('formData', 'data');
-    }
-    catch (_hugeObject) {
+    } catch (_hugeObject) {
+      // handled
     }
   });
 


### PR DESCRIPTION
### Summary

In our codebase, we have this pattern:
```js
animate = (_: ?number) => {};
```

That triggers the unused-vars warning due to the argument being unused. In this instance, the argument is there to pass strong-type checks, and we have a code style guideline that uses prepending of underscore to signify  that the argument (or catch variable) is unused.

This PR adds a narrowing and widening of the no-unused-vars rule:
1.  to ignore unused arguments that begin with an underscore (a narrowing)
2. to report unused caught exceptions that don't begin with an underscore (a widening since unused caught errors was previously OFF by default)

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Test plan

Added code examples to test JS file, verified no errors.
<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
