### PR TITLE
feat: disable no-unused-prop-types rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ module.exports = {
     'promise/prefer-await-to-then': WARNING,
     'react/display-name': OFF,
     'react/no-multi-comp': [WARNING, { "ignoreStateless": true }],
+    'react/no-unused-prop-types': OFF,
     'react/prop-types': OFF,
     'react-native/no-unused-styles': ERROR,
     'no-unused-vars': [ERROR, { 'argsIgnorePattern': '^_', 'caughtErrorsIgnorePattern': '^_' }],


### PR DESCRIPTION


I sifted through the numerous false positive issues, and added a reduction of one of our cases that seemed to match:
https://github.com/yannickcr/eslint-plugin-react/issues/1764

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
We ran into a few false positives with this rule, and it turns out there are over a dozen issues filed in eslint-plugin-react and a few unmerged PRs. Disabling it for now.

### Test plan

I can add an example to the JS files that would fire if the rule is enabled and the false positive isn't fix yet. Let me know if that's necessary to merge and I'll add it.

Will no longer fire on this code (a reduction of a production case):
```js
// @flow
import * as React from 'react';

type Props = {
  maxItems: number,
  itemOpacityOutputRange: Array<number>,
  textOpacityOutputRange: Array<number>,
  itemScaleOutputRange: Array<number>,
  children: Object => React.Node,
};

type State = {
  foo: number,
  bar: number,
};

function computeStateFromProps(props: Props) {
  const { maxItems, itemOpacityOutputRange, textOpacityOutputRange, itemScaleOutputRange } = props;

  if (maxItems && itemOpacityOutputRange && textOpacityOutputRange && itemScaleOutputRange) {
    return { foo: 0, bar: 0 };
  }
  return { foo: 1, bar: 0 };
}

export default class X extends React.PureComponent<Props, State> {
  constructor(props: Props) {
    super(props);
    this.state = computeStateFromProps(props);
  }

  animateItem = (index: ?number) => {
    const { itemScaleOutputRange } = this.props;
    if (itemScaleOutputRange && index) return 0;
    return 1;
  };

  render() {
    const {
      animateItem,
      props: { children },
    } = this;

    return <>{children({ animateItem })}</>;
  }
}
```