### PR TITLE
turn off react/require-default-props

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ module.exports = {
     'react/no-multi-comp': [WARNING, { "ignoreStateless": true }],
     'react/no-unused-prop-types': OFF,
     'react/prop-types': OFF,
+    'react/require-default-props': OFF,
     'react-native/no-unused-styles': ERROR,
     'no-unused-vars': [ERROR, { 'argsIgnorePattern': '^_', 'caughtErrorsIgnorePattern': '^_' }],
     'react-native/split-platform-components': OFF,


### PR DESCRIPTION
We end up turning this off to better support:
-functional components, which are having default props deprecated
-it forces you to put in a value when you *want* undefined for field debuggability
-the hypothetical extra safety checking goes away when using a type checker like TypeScript or flow

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
