### PR TITLE
enable react/jsx-no-bind with backdoors for DOM and refs

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ module.exports = {
   rules: {
     'promise/prefer-await-to-then': WARNING,
     'react/display-name': OFF,
+    'react/jsx-no-bind': [WARNING, { 'ignoreDOMComponents': true, 'ignoreRefs': true }],
     'react/no-multi-comp': [WARNING, { "ignoreStateless": true }],
     'react/no-unused-prop-types': OFF,
     'react/prop-types': OFF,


### PR DESCRIPTION
We've had a few instances of re-renders being caused by anonymous functions being provided inline to props for pure/functional components. Enabling this rule (with the backdoors mentioned) will warn in those instances while still allowing for necessary ergonomics and patterns.

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
