### PR TITLE
Import extensions to support all extensions

### DIFF
--- a/node.js
+++ b/node.js
@@ -46,6 +46,14 @@ module.exports = {
       parser: 'babel-eslint',
       plugins: ['flowtype'],
       extends: ['plugin:flowtype/recommended', 'prettier/flowtype'],
+      settings: {
+        'import/extensions': extensions.ALL,
+        'import/resolver': {
+          node: {
+            extensions: extensions.ALL,
+          },
+        },
+      },
       rules: {
         'no-unused-vars': [ERROR, NO_UNUSED_VARS_OPTIONS],
         'flowtype/no-weak-types': WARNING,
@@ -63,13 +71,13 @@ module.exports = {
       parser: '@typescript-eslint/parser',
       plugins: ['@typescript-eslint/eslint-plugin'],
       settings: {
-        'import/extensions': [...extensions.TS, ...extensions.JS],
+        'import/extensions': extensions.ALL,
         'import/parsers': {
           '@typescript-eslint/parser': extensions.TS,
         },
         'import/resolver': {
           node: {
-            extensions: [...extensions.TS, ...extensions.JS],
+            extensions: extensions.ALL,
           },
         },
       },

--- a/react-native.js
+++ b/react-native.js
@@ -42,10 +42,10 @@ module.exports = {
     {
       files: ['*.js', '*.jsx'],
       settings: {
-        'import/extensions': [...extensions.JS, ...extensions.JS_REACT_NATIVE],
+        'import/extensions': extensions.ALL,
         'import/resolver': {
           node: {
-            extensions: [...extensions.JS, ...extensions.JS_REACT_NATIVE],
+            extensions: extensions.ALL,
           },
         },
       },

--- a/react-native.js
+++ b/react-native.js
@@ -38,28 +38,4 @@ module.exports = {
       version: 'detect',
     },
   },
-  overrides: [
-    {
-      files: ['*.js', '*.jsx'],
-      settings: {
-        'import/extensions': extensions.ALL,
-        'import/resolver': {
-          node: {
-            extensions: extensions.ALL,
-          },
-        },
-      },
-    },
-    {
-      files: ['*.ts', '*.tsx'],
-      settings: {
-        'import/extensions': extensions.ALL,
-        'import/resolver': {
-          node: {
-            extensions: extensions.ALL,
-          },
-        },
-      },
-    },
-  ],
 };


### PR DESCRIPTION
### Summary

When using offical React Native CLI template for typescript (react-native-template-typescript) the CLI creates project with index.js file which imports App.tsx. Current @callstack/eslint-config did not support .js files importing .ts/.tsx files. I've changed the rule for react-native and node so that 

### Test plan

1. Create an empty React Native app using `npx react-native init AwesomeTSProject --template react-native-template-typescript`
2. Add @callstack/eslint-config using `yarn add --dev @callstack/eslint-config`
3. Run `yarn lint`

Using the current version it will fail with "Unable to resolve path to module './App'" for index.js.
PR version should work fine.
