### PR TITLE
update eslint-plugin-import

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "babel-eslint": "^10.0.3",
     "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-flowtype": "^4.5.2",
-    "eslint-plugin-import": "^2.19.1",
+    "eslint-plugin-import": "^2.25.2",
     "eslint-plugin-jest": "^25.0.5",
     "eslint-plugin-prettier": "^3.1.3",
     "eslint-plugin-promise": "^4.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -618,7 +618,7 @@ eslint-plugin-flowtype@^4.5.2:
   dependencies:
     lodash "^4.17.15"
 
-eslint-plugin-import@^2.19.1:
+eslint-plugin-import@^2.25.2:
   version "2.25.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.25.2.tgz#b3b9160efddb702fc1636659e71ba1d10adbe9e9"
   integrity sha512-qCwQr9TYfoBHOFcVGKY9C9unq05uOxxdklmBXLVvcwo68y5Hta6/GzCZEMx2zQiu0woKNEER0LE7ZgaOfBU14g==


### PR DESCRIPTION
Update eslint-plugin-import to the newest version. It includes fixes that improve compatibility with projects that use Webpack 5.

### Summary

It should fix an issue with Webpack 5 compatibility:
https://github.com/import-js/eslint-plugin-import/issues/1931

### Test plan

Pipelines succeed. Rule checking works correctly.
