### PR TITLE
chore: remove dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: monthly
-  open-pull-requests-limit: 10


### PR DESCRIPTION
Remove Dependabot from the project. It seems that it is not used much and bigger updates still require manual input from the maintainer.