### PR TITLE
chore: do not require users to install parsers in their project

### DIFF
--- a/node.js
+++ b/node.js
@@ -26,6 +26,11 @@ module.exports = {
   parserOptions: {
     sourceType: 'module',
   },
+  settings: {
+    flowtype: {
+      onlyFilesWithFlowAnnotation: true,
+    },
+  },
   rules: {
     'import/extensions': OFF,
     'import/no-dynamic-require': OFF,
@@ -46,12 +51,10 @@ module.exports = {
       files: ['*.js', '*.jsx'],
       parser: '@babel/eslint-parser',
       parserOptions: {
-        babelOptions: {
-          presets: ['@babel/preset-flow'],
-        },
+        requireConfigFile: false
       },
       plugins: ['flowtype'],
-      extends: ['plugin:flowtype/recommended', 'prettier'],
+      extends: ['plugin:flowtype/recommended'],
       settings: {
         'import/extensions': [...extensions.JS, ...extensions.TS],
         'import/resolver': {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,6 @@
   "dependencies": {
     "@babel/core": "^7.16.0",
     "@babel/eslint-parser": "^7.16.3",
-    "@babel/preset-flow": "^7.16.0",
-    "@babel/preset-react": "^7.16.0",
     "@typescript-eslint/eslint-plugin": "^5.4.0",
     "@typescript-eslint/parser": "^5.4.0",
     "eslint-config-prettier": "^8.3.0",

--- a/react.js
+++ b/react.js
@@ -13,16 +13,6 @@ module.exports = {
       jsx: true,
     },
   },
-  overrides: [
-    {
-      files: ['*.js', '*.jsx'],
-      parserOptions: {
-        babelOptions: {
-          presets: ['@babel/preset-react', '@babel/preset-flow'],
-        },
-      },
-    },
-  ],
   rules: {
     'react/display-name': OFF,
     'react/no-multi-comp': [WARNING, { ignoreStateless: true }],

--- a/yarn.lock
+++ b/yarn.lock
@@ -255,27 +255,12 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.16.4.tgz#d5f92f57cf2c74ffe9b37981c0e72fee7311372e"
   integrity sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==
 
-"@babel/plugin-syntax-flow@^7.16.0":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.16.0.tgz#07427021d093ed77019408221beaf0272bbcfaec"
-  integrity sha512-dH91yCo0RyqfzWgoM5Ji9ir8fQ+uFbt9KHM3d2x4jZOuHS6wNA+CRmRUP/BWCsHG2bjc7A2Way6AvH1eQk0wig==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.14.5"
-
 "@babel/plugin-syntax-jsx@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.16.0.tgz#f9624394317365a9a88c82358d3f8471154698f1"
   integrity sha512-8zv2+xiPHwly31RK4RmnEYY5zziuF3O7W2kIDW+07ewWDh6Oi0dRq8kwvulRkFgt6DB97RlKs5c1y068iPlCUg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
-
-"@babel/plugin-transform-flow-strip-types@^7.16.0":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.16.0.tgz#edd968dc2041c1b69e451a262e948d6654a79dc2"
-  integrity sha512-vs/F5roOaO/+WxKfp9PkvLsAyj0G+Q0zbFimHm9X2KDgabN2XmNFoAafmeGEYspUlIF9+MvVmyek9UyHiqeG/w==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.14.5"
-    "@babel/plugin-syntax-flow" "^7.16.0"
 
 "@babel/plugin-transform-react-display-name@^7.16.0":
   version "7.16.0"
@@ -309,15 +294,6 @@
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.16.0"
     "@babel/helper-plugin-utils" "^7.14.5"
-
-"@babel/preset-flow@^7.16.0":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@babel/preset-flow/-/preset-flow-7.16.0.tgz#9f1f6e72714d79460d48058cb5658fc87da7150b"
-  integrity sha512-e5NE1EoPMpoHFkyFkMSj2h9tu7OolARcUHki8mnBv4NiFK9so+UrhbvT9mV99tMJOUEx8BOj67T6dXvGcTeYeQ==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.14.5"
-    "@babel/helper-validator-option" "^7.14.5"
-    "@babel/plugin-transform-flow-strip-types" "^7.16.0"
 
 "@babel/preset-react@^7.16.0":
   version "7.16.0"


### PR DESCRIPTION
This PR removes requirement for consumers of this config to install parsers used within. Instead it will use babel config that user has in their project.

### Summary

After recent update to the newest eslint parser changes in config forced users to install all parsers used in this project. This is a bit inconvenient as it makes developers install for example Flow parser even though they are not using it in their project.

Submitted changes are the attempt to fix and simplify setup for consumers of this config.

It was inspired by config created by @satya164.
https://github.com/satya164/eslint-config-satya164/blob/master/index.js

### Test plan

Install new config to a project and verify that rules are applied correctly.
