### PR TITLE
chore: add recommended rules from typescript eslint

### DIFF
--- a/node.js
+++ b/node.js
@@ -78,7 +78,8 @@ module.exports = {
     {
       files: ['*.ts', '*.tsx'],
       parser: '@typescript-eslint/parser',
-      plugins: ['@typescript-eslint/eslint-plugin'],
+      plugins: ['@typescript-eslint'],
+      extends: ['plugin:@typescript-eslint/recommended'],
       settings: {
         'import/extensions': [...extensions.TS, ...extensions.JS],
         'import/parsers': {


### PR DESCRIPTION
Add recommended rules from Typescript Eslint.

### Summary

Adds new rules to improve quality of code of the projects that use this config.
https://typescript-eslint.io/docs/linting/

There are also additional rules that use Typescript typechecking to verify code in a way that is not possible only with Eslint, but at the moment I'm not sure how to configure it in an external config. 
At the moment only way to configure it seems to be for the user to setup an override in their configuration and add it manually themselves.
https://typescript-eslint.io/docs/linting/type-linting

On the other hand using TS for Eslint rule checking has a performance penalty that not everyone might want to pay, even though it is encouraged as type-aware linting has "additional powers" that are not possible without it.
https://typescript-eslint.io/docs/linting/type-linting#how-is-performance

### Test plan

Verify that linting works fine and new rules are enforced.
