### PR TITLE
fix: add missing ignoreRestSiblings to allow to omit values

### DIFF
--- a/node.js
+++ b/node.js
@@ -6,6 +6,7 @@ const WARNING = 1;
 const ERROR = 2;
 
 const NO_UNUSED_VARS_OPTIONS = {
+  ignoreRestSiblings: true,
   argsIgnorePattern: '^_',
   caughtErrorsIgnorePattern: '^_',
 };


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Add missing `ignoreRestSiblings` to allow to omit values in destructuring assignment.

Without `ignoreRestSiblings: true` this code fails:
```ts
const { modalDialogs: _, ...rest } = (params ?? {}) as InternalParams;
// error  '_' is assigned a value but never used  @typescript-eslint/no-unused-vars
```
