### PR TITLE
Disable 'react-native-a11y/has-accessibility-hint'

### DIFF
--- a/react-native.js
+++ b/react-native.js
@@ -16,6 +16,7 @@ module.exports = {
     'react-native/no-inline-styles': WARNING,
     'react-native/no-color-literals': WARNING,
     'react-native/no-raw-text': ERROR,
+    'react-native-a11y/has-accessibility-hint': OFF,
   },
   overrides: [
     {


### PR DESCRIPTION
'react-native-a11y/has-accessibility-hint' is too strict and incorrect in some cases.
I think it would be a good idea to turn it off by default.

https://github.com/FormidableLabs/eslint-plugin-react-native-a11y/issues/142

### Test plan

Pipelines pass.
