### PR TITLE
chore: add `require-await` rule

### DIFF
--- a/node.js
+++ b/node.js
@@ -45,13 +45,14 @@ module.exports = {
       ERROR,
       { devDependencies: TEST_PATTERNS },
     ],
+    'require-await': ERROR,
   },
   overrides: [
     {
       files: ['*.js', '*.jsx'],
       parser: '@babel/eslint-parser',
       parserOptions: {
-        requireConfigFile: false
+        requireConfigFile: false,
       },
       plugins: ['flowtype'],
       extends: ['plugin:flowtype/recommended'],

--- a/test/index.js
+++ b/test/index.js
@@ -53,6 +53,11 @@ export function Hook() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // eslint-disable-next-line require-await
+  async () => {
+    new Promise((resolve) => resolve('test'));
+  };
+
   return (
     <>
       {/* eslint-disable-next-line react-native/no-inline-styles, react-native/no-color-literals */}

--- a/test/index.tsx
+++ b/test/index.tsx
@@ -53,6 +53,11 @@ export function Hook() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // eslint-disable-next-line require-await
+  async () => {
+    new Promise((resolve) => resolve('test'));
+  };
+
   return (
     <>
       {/* eslint-disable-next-line react-native/no-inline-styles, react-native/no-color-literals */}


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Added the [require-await](https://eslint.org/docs/latest/rules/require-await) rule. Suggested here: https://github.com/callstack/reassure/pull/317#discussion_r1086427553

### Test plan

Modified `test/index.js` and `test/index.tsx`. CI should pass.
