### PR TITLE
fix: update vscode settings config of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,22 +123,10 @@ If you're VSCode user, you may find adding this config to your `.vscode/settings
 ```json
 {
   "eslint.validate": [
-    {
-      "language": "javascript",
-      "autoFix": true
-    },
-    {
-      "language": "javascriptreact",
-      "autoFix": true
-    },
-    {
-      "language": "typescript",
-      "autoFix": true
-    },
-    {
-      "language": "typescriptreact",
-      "autoFix": true
-    }
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact"
   ]
 }
 ```


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
The issue (#263) is that there is a little bit deprecated [suggestion](https://github.com/callstack/eslint-config-callstack#vscode) for VSCode settings config. Once I've added `@callstack/eslint-config` I saw a warning _(check a screenshot below)_. 
Looks like there was an update where `autoFix` started to be a default value. No sense to set it explicitly anymore. So I've updated `README.md`.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

1. Add [@callstack/eslint-config](https://github.com/callstack/eslint-config-callstack#callstackeslint-config) to a project
2. Add [VSCode config](https://github.com/callstack/eslint-config-callstack#vscode) to your `.vscode/settings.json`

### Initial warning
<img width="500" alt="Screenshot 2023-06-05 at 15 19 17" src="https://github.com/callstack/eslint-config-callstack/assets/57314631/6aad2752-9844-4289-846d-d1e9e9c94f87">

### Fix
<img width="500" alt="Screenshot 2023-06-05 at 15 19 01" src="https://github.com/callstack/eslint-config-callstack/assets/57314631/95c4b209-c46b-4727-9a94-013614f752fc">
