### PR TITLE
Include repo and homepage in the npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,11 @@
     "node": ">=18.0.0"
   },
   "main": "./react-native.js",
-  "repository": "git@github.com:callstack/eslint-config-callstack.git",
+  "homepage": "https://github.com/callstack/eslint-config-callstack#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/callstack/eslint-config-callstack.git"
+  },
   "author": "Michał Pierzchała <thymikee@gmail.com>",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
This pull request closes #272 
It adds both `homepage` and extended `repository` fields to the package config so that both links are visible in the npm page of the package.