### PR TITLE
Add bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "type": "git",
     "url": "https://github.com/callstack/eslint-config-callstack.git"
   },
+  "bugs": {
+    "url": "https://github.com/callstack/eslint-config-callstack/issues"
+  },
   "author": "Michał Pierzchała <thymikee@gmail.com>",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
## Summary

Adds missing bugs metadata to the package manifest for `@callstack/eslint-config`.

The package already points at this repository, and GitHub issues are enabled for `callstack/eslint-config-callstack`.

## Verification

- Confirmed current npm metadata for `@callstack/eslint-config@15.0.0` has no bugs field.
- Verified the updated package manifest now points `bugs.url` to the repository issues page.
- Ran `git diff --check`.
- Ran `npm pack --dry-run --ignore-scripts --json`.
