### PR TITLE
Add package bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "type": "git",
     "url": "https://github.com/callstack/eslint-config-callstack.git"
   },
+  "bugs": {
+    "url": "https://github.com/callstack/eslint-config-callstack/issues"
+  },
   "author": "Michał Pierzchała <thymikee@gmail.com>",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
## Summary

Adds `bugs.url` metadata to the package manifest so npm users can find the public issue tracker directly from `@callstack/eslint-config` package metadata.

This is a metadata-only change to `package.json`; runtime code, dependencies, exports, and build behavior are unchanged.

## Validation

```bash
node -e "const p=require('./package.json'); console.log(JSON.stringify({name:p.name,version:p.version,repository:p.repository,homepage:p.homepage,bugs:p.bugs,license:p.license},null,2)); if(p.name!=='@callstack/eslint-config'||p.bugs?.url!=='https://github.com/callstack/eslint-config-callstack/issues') process.exit(1)"
git diff --check
npm pack @callstack/eslint-config@15.0.0 --dry-run --json
```